### PR TITLE
Fix bionode-ncbi example

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -88,7 +88,7 @@ db | none | [One of these](#bionode-ncbi-database)
 term | none | Species, dataset ID, etc
 
 ```shell
-bionode-ncbi search search taxonomy 'solenopsis invicta' --limit 1 --pretty
+bionode-ncbi search taxonomy 'solenopsis invicta' --limit 1 --pretty
 ```
 
 ```javascript


### PR DESCRIPTION
The bionode-ncbi example had an extra "search" parameter that breaks the
example usage, so the extra parameter was removed.

If I'm targeting the wrong branch, let me know.